### PR TITLE
Fix Toolbar Scrolling and Mention viewport width resizing

### DIFF
--- a/SwiftyDraft/Classes/SwiftyDraftJavaScriptBridge.swift
+++ b/SwiftyDraft/Classes/SwiftyDraftJavaScriptBridge.swift
@@ -277,9 +277,17 @@ extension SwiftyDraft: WKScriptMessageHandler {
         }
     }
 
+    private func injectCSS() {
+        // fix mentions to the left
+        let cssString = ".draftJsMentionPlugin__mentionSuggestions__2DWjA { left: 2px !important }"
+        let jsString = "var style = document.createElement('style'); style.innerHTML = '\(cssString)'; document.head.appendChild(style);"
+        webView.evaluateJavaScript(jsString, completionHandler: nil)
+    }
+
     // MARK: - WKNavigationDelegate
     
     @objc(webView:didFinishNavigation:) public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        injectCSS()
         if !editorInitialized {
             if isFirstResponder {
                 focus()

--- a/SwiftyDraft/Classes/Toolbar.swift
+++ b/SwiftyDraft/Classes/Toolbar.swift
@@ -88,7 +88,7 @@ public class Toolbar: UIView {
         toolbar.backgroundColor = UIColor.clear
         let borderTop = CALayer()
         borderTop.backgroundColor = UIColor.clear.cgColor
-        borderTop.frame = CGRect(x: 0, y: 0, width: 9999, height: 1.0)
+        borderTop.frame = CGRect(x: 0, y: 0, width: self.frame.width, height: 1.0)
         layer.addSublayer(borderTop)
         let f = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         var items: [UIBarButtonItem] = [f]
@@ -210,7 +210,6 @@ public class Toolbar: UIView {
         toolbar.frame = CGRect(origin: CGPoint.zero,
                                size: CGSize(width: b.size.width, height: 44))
         scrollView.frame = CGRect(origin: CGPoint(x: 0, y: b.height - 44), size: b.size)
-        scrollView.contentSize = toolbarSize
         lineView?.frame = CGRect(x: 0, y: 0, width: self.frame.width, height: 1)
         let f = CGRect(x: b.width - closeButtonWidth, y: 0, width: closeButtonWidth, height: 44)
         closeButton.frame = f


### PR DESCRIPTION
QA Issue 1: https://app.asana.com/0/355261742377699/687848440502796
GIF Issue 2, 3: https://one-team.slack.com/archives/C07FE3FGA/p1533629088000367

* Override CSS positioning of SwiftyDraft//draft-js-mention-plugin to prevent viewport content width resizing
* Prevent toolbar horizontal scrolling