### PR TITLE
App-extension safe API

### DIFF
--- a/Example/SwiftyDraftExample.xcodeproj/project.pbxproj
+++ b/Example/SwiftyDraftExample.xcodeproj/project.pbxproj
@@ -253,6 +253,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -300,6 +301,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/SwiftyDraft/Classes/SwiftyDraft.swift
+++ b/SwiftyDraft/Classes/SwiftyDraft.swift
@@ -164,10 +164,6 @@ func localizedStringForKey(key: String) -> String {
     }
 
     public func promptEmbedCode() {
-        guard let vc = UIApplication.shared.keyWindow?.visibleViewController else {
-            assertionFailure("View Controller does not exist")
-            return
-        }
         let ac = UIAlertController(
             title: SwiftyDraft.localizedStringForKey(key: "embed_iframe.prompt.title"),
             message: SwiftyDraft.localizedStringForKey(key: "embed_iframe.prompt.message"),
@@ -192,14 +188,16 @@ func localizedStringForKey(key: String) -> String {
             style: .cancel, handler: { _ in
                 self.focus(delayed: true)
         }))
+        let win = UIWindow(frame: UIScreen.main.bounds)
+        let vc = UIViewController()
+        vc.view.backgroundColor = .clear
+        win.rootViewController = vc
+        win.windowLevel = UIWindowLevelAlert + 1
+        win.makeKeyAndVisible()
         vc.present(ac, animated: true, completion: nil)
     }
 
     public func promptLinkURL() {
-        guard let vc = UIApplication.shared.keyWindow?.visibleViewController else {
-            assertionFailure("View Controller does not exist")
-            return
-        }
         let ac = UIAlertController(
             title: SwiftyDraft.localizedStringForKey(key: "insert_link.prompt.title"),
             message: SwiftyDraft.localizedStringForKey(key: "insert_link.prompt.message"),
@@ -219,6 +217,12 @@ func localizedStringForKey(key: String) -> String {
         ac.addAction(UIAlertAction(title: SwiftyDraft.localizedStringForKey(key: "button.cancel"), style: .cancel, handler: { _ in
             self.focus(delayed: true)
         }))
+        let win = UIWindow(frame: UIScreen.main.bounds)
+        let vc = UIViewController()
+        vc.view.backgroundColor = .clear
+        win.rootViewController = vc
+        win.windowLevel = UIWindowLevelAlert + 1
+        win.makeKeyAndVisible()
         vc.present(ac, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
To prepare SwiftyDraft/Draft.js for the Share Extension.

Wasn't able to test the change because the `.InsertLink` and `.EmbedCode` don't seem to be used on the SwiftyDraft toolbar(?).

```swift
open func toolbarButtonTapped(_ buttonTag: ButtonTag, _ item: UIBarButtonItem, toolBar: Toolbar) {
        
        if toolBar == editorToolbar {
            switch buttonTag {
            case .InsertLink:
                promptLinkURL() // <-- here
            case .EmbedCode:
                promptEmbedCode() // <-- here
```