### PR TITLE
Interface Builder crashing with multiple targets

### DIFF
--- a/SwiftyDraft/Classes/SwiftyDraft.swift
+++ b/SwiftyDraft/Classes/SwiftyDraft.swift
@@ -13,7 +13,7 @@ func localizedStringForKey(key: String) -> String {
     return SwiftyDraft.localizedStringForKey(key: key)
 }
 
-@IBDesignable open class SwiftyDraft: UIView, WKNavigationDelegate {
+open class SwiftyDraft: UIView, WKNavigationDelegate {
 
     public weak var imagePickerDelegate: SwiftyDraftImagePickerDelegate?
     public weak var filePickerDelegate: SwiftyDraftFilePickerDelegate?


### PR DESCRIPTION
IB is going crazy (always compiling in xcode) for some reason while trying to implement SwiftyDraft into multiple targets (main app and appex). We're not using `@IBInspectable` properties anyways so I think it should be fine to remove it!

Getting errors like:
>IB Designables: Using class UIButton for object with custom class because the class _TtC6CStagingOneteamSwiftyDraftEditor does not exist.
>
>TopicCompose.storyboard: error: IB Designables: Failed to render instance of SwiftyDraftEditor: The agent crashed