### PR TITLE
Trigger state change after file upload

### DIFF
--- a/SwiftyDraft/Classes/SwiftyDraft.swift
+++ b/SwiftyDraft/Classes/SwiftyDraft.swift
@@ -123,7 +123,7 @@ open class SwiftyDraft: UIView, WKNavigationDelegate {
         self.webView.backgroundColor = UIColor.white
         self.webView.addRichEditorInputAccessoryView(toolbar: self.editorToolbar)
         let js = try! String(contentsOf: SwiftyDraft.javaScriptURL)
-        let html = try! String(contentsOf: SwiftyDraft.htmlURL).replacingOccurrences(of: " src=\"./bundle.js\"><", with: "> window.onerror = function(e) { document.location.href = \"callback-\(callbackToken)://error.internal/\(WebViewCallback.DebugLog.rawValue)/\" + encodeURIComponent(JSON.stringify({ error: '' + e })); } </script><script>\(js)<")
+        let html = try! String(contentsOf: SwiftyDraft.htmlURL).replacingOccurrences(of: " src=\"./bundle.js\"><", with: "> window.onerror = function(e) { document.location.href = \"callback-\(callbackToken)://error.internal/\(WebViewCallback.debugLog.rawValue)/\" + encodeURIComponent(JSON.stringify({ error: '' + e })); } </script><script>\(js)<")
         self.webView.loadHTMLString(html, baseURL: baseURL)
         
         NotificationCenter.default.addObserver(self, selector: #selector(SwiftyDraft.handleKeyboardChangeFrame(_:)),

--- a/SwiftyDraft/Classes/SwiftyDraft.swift
+++ b/SwiftyDraft/Classes/SwiftyDraft.swift
@@ -83,7 +83,7 @@ open class SwiftyDraft: UIView, WKNavigationDelegate {
 
     public lazy var userContentController: WKUserContentController = {
         let uc = WKUserContentController()
-        WebViewCallback.all.forEach {
+        WebViewCallback.allCases.forEach {
             uc.add(self, name: $0.rawValue)
         }
         return uc

--- a/SwiftyDraft/Classes/SwiftyDraftJavaScriptBridge.swift
+++ b/SwiftyDraft/Classes/SwiftyDraftJavaScriptBridge.swift
@@ -222,7 +222,9 @@ extension SwiftyDraft: WKScriptMessageHandler {
     func didChangeEditorState(html: String, inlineStyles: [InlineStyle], blockType: BlockType, isFocus:Bool) {
         self.editorToolbar.currentInlineStyles = inlineStyles
         self.editorToolbar.currentBlockType = blockType
-        self.html = html
+        if editorInitialized {
+            self.html = html
+        }
         if editing == false && isFocus == true {
             scrollY(offset: paddingTop - 10)
         }

--- a/SwiftyDraft/Classes/SwiftyDraftJavaScriptBridge.swift
+++ b/SwiftyDraft/Classes/SwiftyDraftJavaScriptBridge.swift
@@ -247,9 +247,9 @@ extension SwiftyDraft: WKScriptMessageHandler {
 
     private func handleWebViewCallback(callback: WebViewCallback, data: AnyObject?) {
         switch callback {
-        case .DidSetCallbackToken:
+        case .didSetCallbackToken:
             didSetCallbackToken(token: data as! String)
-        case .DidChangeEditorState:
+        case .didChangeEditorState:
             let inlineStyles = ((data?["inlineStyles"] as? [String]) ?? [String]()).compactMap({ InlineStyle(rawValue: $0) })
             let blockType = BlockType(rawValue: (data?["blockType"] as? String) ?? "") ?? .Unstyled
             let html = data?["html"] as? String ?? ""
@@ -259,7 +259,7 @@ extension SwiftyDraft: WKScriptMessageHandler {
             }
             didChangeEditorState(html: html, inlineStyles: inlineStyles, blockType: blockType, isFocus: isFocused)
 
-        case .DebugLog:
+        case .debugLog:
             print("[DEBUG] \(data)")
         }
     }

--- a/SwiftyDraft/Classes/WebViewCallback.swift
+++ b/SwiftyDraft/Classes/WebViewCallback.swift
@@ -8,10 +8,8 @@
 
 import Foundation
 
-enum WebViewCallback: String {
-    case DebugLog = "debugLog"
-    case DidSetCallbackToken = "didSetCallbackToken"
-    case DidChangeEditorState = "didChangeEditorState"
-
-    static let all: [WebViewCallback] = [DebugLog, DidSetCallbackToken, DidChangeEditorState]
+enum WebViewCallback: String, CaseIterable {
+    case debugLog
+    case didSetCallbackToken
+    case didChangeEditorState
 }

--- a/SwiftyDraft/Sources/SwiftyDraft.js
+++ b/SwiftyDraft/Sources/SwiftyDraft.js
@@ -40,6 +40,7 @@ export default class SwiftyDraft extends Component {
     insertDownloadLink(...args) {
         if(this.editor) {
             this.editor.html += "<a href=\"" + arguments[0]["url"] + "\" target=\"_blank\">"+ arguments[0]["title"] +"</a>"
+            this.editor.focus();
         }
     }
     insertIFrame(tag) {


### PR DESCRIPTION
The `RichTextEditor` component doesn't trigger a state change after adding the file upload HTML manually to the editor object. Fixed so file uploads will always show up on the native Swift side.